### PR TITLE
Addresses feedback round from 10/14/2020 and 10/15/2020

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -56,10 +56,6 @@
       "slots": [],
       "cssProperties": [
         {
-          "name": "--defaultBookmarkColor",
-          "description": "Default bookmark color",
-          "type": "Color"
-        }, {
           "name": "--blueBookmarkColor",
           "description": "Blue bookmark color",
           "type": "Color"
@@ -72,10 +68,6 @@
           "description": "Green bookmark color",
           "type": "Color"
         }, {
-          "name": "--yellowBookmarkColor",
-          "description": "Yellow bookmark color",
-          "type": "Color"
-        }, {
           "name": "--saveButtonColor",
           "description": "Save button color",
           "type": "Color"
@@ -83,6 +75,10 @@
           "name": "--deleteButtonColor",
           "description": "Delete button color",
           "type": "Color"
+        }, {
+          "name": "--buttonWidth",
+          "description": "Save and delete button widths",
+          "type": "Dimension"
         }
       ]
     }

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -79,6 +79,10 @@
           "name": "--buttonWidth",
           "description": "Save and delete button widths",
           "type": "Dimension"
+        }, {
+          "name": "--loadingPagePlaceholder",
+          "description": "Background color of page thumbnail",
+          "type": "Color"
         }
       ]
     }

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,14 +25,13 @@
       --closeMenuIconWidth: 20px;
       --closeMenuIconHeight: 20px;
 
-      --defaultBookmarkColor: #282828;
       --blueBookmarkColor: #0023f5;
       --redBookmarkColor: #eb3223;
       --greenBookmarkColor: #75ef4c;
-      --yellowBookmarkColor: #fffd54;
       --saveButtonColor: #538bc5;
       --deleteButtonColor: #d33630;
       --bookmarkThumbWidth: 37px;
+      --buttonWidth: 200px;
     }
 
     html {
@@ -78,24 +77,18 @@
       thumbnail: '//placehold.it/320x496/06c/fff',
       page: 9,
       note: 'This is a long comment I left about this bookmark in order to test out the display in the panel on the side of the bookreader.',
-      color: 0,
+      color: 1,
     };
 
     const bookmarkColors = [{
       id: 0,
-      className: '',
-    }, {
-      id: 1,
       className: 'blue',
     }, {
-      id: 2,
+      id: 1,
       className: 'red',
     }, {
-      id: 3,
+      id: 2,
       className: 'green',
-    }, {
-      id: 4,
-      className: 'yellow',
     }];
 
     const menuSlider = document.createElement('ia-menu-slider');

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,6 +30,7 @@
       --greenBookmarkColor: #75ef4c;
       --saveButtonColor: #538bc5;
       --deleteButtonColor: #d33630;
+      --loadingPagePlaceholder: #fefdeb;
       --bookmarkThumbWidth: 37px;
       --buttonWidth: 200px;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-bookmark-edit",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-bookmark-edit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Bookmark edit component for ia-menu-slider",
   "author": "Shane Riley, Internet Archive",
   "license": "AGPL-3.0-only",

--- a/src/ia-bookmark-edit.js
+++ b/src/ia-bookmark-edit.js
@@ -85,12 +85,13 @@ export class IABookmarkEdit extends LitElement {
       <form action="" method="put" @submit=${this.emitSaveEvent}>
         <fieldset>
           <label for="note">Note <small>(optional)</small></label>
-          <p>Comments appear in the bookmarks menu.</p>
           <textarea rows="4" cols="80" name="note" id="note" @change=${this.updateNote}>${this.bookmark.note}</textarea>
-          <label for="color">Bookmark color</label>
-          <ul>
-            ${repeat(this.bookmarkColors, color => color.id, this.bookmarkColor.bind(this))}
-          </ul>
+          <div class="color">
+            <label for="color">Bookmark color</label>
+            <ul>
+              ${repeat(this.bookmarkColors, color => color.id, this.bookmarkColor.bind(this))}
+            </ul>
+          </div>
           <div class="justify">
             <input class="button" type="submit" value="Save changes" />
           </div>

--- a/src/styles/ia-bookmark-edit.js
+++ b/src/styles/ia-bookmark-edit.js
@@ -21,6 +21,8 @@ small {
 img {
   display: block;
   width: var(--bookmarkThumbWidth);
+  min-height: calc(var(--bookmarkThumbWidth) * 1.55);
+  background: var(--loadingPagePlaceholder);
 }
 
 h4 {

--- a/src/styles/ia-bookmark-edit.js
+++ b/src/styles/ia-bookmark-edit.js
@@ -52,12 +52,18 @@ textarea {
   resize: vertical;
 }
 
+.color {
+  width: var(--buttonWidth);
+  margin: 0 auto 2rem auto;
+}
+
 ul {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(3, auto);
   grid-gap: 0 1rem;
+  justify-content: space-between;
   padding: 1rem 0 0 0;
-  margin: 0 0 2rem 0;
+  margin: 0;
   list-style: none;
 }
 
@@ -67,7 +73,8 @@ li input {
 
 li label {
   display: block;
-  padding-top: .2rem;
+  min-width: 50px;
+  padding-top: .4rem;
   text-align: center;
   border: 1px solid #fff;
   border-radius: 4px;
@@ -91,6 +98,8 @@ button {
   -webkit-appearance: none;
   appearance: none;
   padding: .5rem 1rem;
+  min-width: var(--buttonWidth);
+  box-sizing: border-box;
   font: normal 1.3rem "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: var(--primaryTextColor);
   border: none;
@@ -103,10 +112,6 @@ button {
   text-align: center;
 }
 
-icon-bookmark {
-  --iconFillColor: var(--defaultBookmarkColor);
-}
-
 .blue {
   --iconFillColor: var(--blueBookmarkColor);
 }
@@ -117,9 +122,5 @@ icon-bookmark {
 
 .green {
   --iconFillColor: var(--greenBookmarkColor);
-}
-
-.yellow {
-  --iconFillColor: var(--yellowBookmarkColor);
 }
 `;


### PR DESCRIPTION
* Resizes buttons to 200px
* Removes gray and yellow bookmarks color options
* Removes explanatory text for note field

<img width="316" alt="Screen Shot 2020-10-15 at 3 46 14 PM" src="https://user-images.githubusercontent.com/39553/96178575-92f55b00-0efd-11eb-8aa0-3a4bfd790590.png">
